### PR TITLE
Remove ruby version from the gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-ruby "3.2.2"
-
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.1.1"
 


### PR DESCRIPTION
Because we don't want the app to break if we upgrade the ruby version on the server